### PR TITLE
CU-2069pcb - Update Vulcan Event Types page for non-admin users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,9 @@ CALENDSO_ENCRYPTION_KEY=
 
 # Intercom Config
 NEXT_PUBLIC_INTERCOM_APP_ID=
+
+# Required for auth login redirect
+THETIS_SITE_HOST=http://localhost:3001
+
+# Requried to identify Thetis Admin Users
+THETIS_ADMIN_USER_EMAILS=test@example.com;

--- a/pages/getting-started.tsx
+++ b/pages/getting-started.tsx
@@ -51,20 +51,9 @@ export default function Onboarding(props: inferSSRProps<typeof getServerSideProp
 
   const DEFAULT_EVENT_TYPES = [
     {
-      title: t("15min_meeting"),
-      slug: "15min",
-      length: 15,
-    },
-    {
       title: t("30min_meeting"),
       slug: "30min",
       length: 30,
-    },
-    {
-      title: t("secret_meeting"),
-      slug: "secret",
-      length: 15,
-      hidden: true,
     },
   ];
 

--- a/server/routers/viewer.tsx
+++ b/server/routers/viewer.tsx
@@ -104,6 +104,7 @@ const loggedInViewerRouter = createProtectedRouter()
         },
         select: {
           id: true,
+          email: true,
           username: true,
           name: true,
           startTime: true,
@@ -235,8 +236,9 @@ const loggedInViewerRouter = createProtectedRouter()
           eventTypes: membership.team.eventTypes,
         }))
       );
-
-      const canAddEvents = user.plan !== "FREE" || eventTypeGroups[0].eventTypes.length < 1;
+      
+      const isAdminUser = process.env.THETIS_ADMIN_USER_EMAILS?.split(";").includes(user.email);
+      const canAddEvents = isAdminUser // user.plan !== "FREE" || eventTypeGroups[0].eventTypes.length < 1;
 
       return {
         viewer: {


### PR DESCRIPTION
- New Event Type button is disabled for user emails that are not present in `THETIS_ADMIN_USER_EMAILS`
- New onboarded users will only see 30 minute meeting